### PR TITLE
adding docker build and health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax = docker/dockerfile:experimental
+FROM golang:1.15 as builder
+
+ENV GRPC_HEALTH_PROBE_VERSION="v0.3.1"
+RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.sum /workspace/
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY proto/ proto/
+COPY protodeps/ protodeps/
+COPY server/ server/
+
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o rode main.go
+
+# ---------------
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/rode .
+COPY --from=builder /bin/grpc_health_probe .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/rode"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liatrio/rode-api
 
-go 1.14
+go 1.15
 
 require (
 	github.com/brianvoe/gofakeit/v5 v5.10.1
@@ -8,8 +8,9 @@ require (
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3
 	go.uber.org/zap v1.16.0
-	golang.org/x/exp v0.0.0-20190121172915-509febef88a4
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+	golang.org/x/net v0.0.0-20201022231255-08b38378de70 // indirect
+	golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd // indirect
+	google.golang.org/genproto v0.0.0-20201022181438-0ff5f38871d5
 	google.golang.org/grpc v1.33.1
 	google.golang.org/protobuf v1.25.0
 )

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0 h1:wBouT66WTYFXdxfVdz9sVWARVd/2vfGcmI45D2gj45M=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201022231255-08b38378de70 h1:Z6x4N9mAi4oF0TbHweCsH618MO6OI6UFgV0FP5n0wBY=
+golang.org/x/net v0.0.0-20201022231255-08b38378de70/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -110,6 +112,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd h1:WgqgiQvkiZWz7XLhphjt2GI2GcGCTIZs9jqXMWmH+oc=
+golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -134,6 +138,8 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2El
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
+google.golang.org/genproto v0.0.0-20201022181438-0ff5f38871d5 h1:YejJbGvoWsTXHab4OKNrzk27Dr7s4lPLnewbHue1+gM=
+google.golang.org/genproto v0.0.0-20201022181438-0ff5f38871d5/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
@@ -149,6 +155,7 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/scripts/generate/entrypoint.sh
+++ b/scripts/generate/entrypoint.sh
@@ -34,17 +34,17 @@ grep -rl 'github.com/grafeas/grafeas' ./*.proto | xargs sed -i 's+github.com/gra
 # next, generate go code from the grafeas protobuf definitions
 
 function generate {
-  protoc -I . -I ../.. -I ../../../googleapis --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative $1.proto
-  rm -rf "${1}_go_proto"
-  mkdir "${1}_go_proto"
-  mv ${1}.pb.go ${1}_go_proto
-  if test -f "${1}_grpc.pb.go"; then
-    mv ${1}_grpc.pb.go ${1}_go_proto
-  fi
+    protoc -I . -I ../.. -I ../../../googleapis --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative $1.proto
+    rm -rf "${1}_go_proto"
+    mkdir "${1}_go_proto"
+    mv ${1}.pb.go ${1}_go_proto
+    if test -f "${1}_grpc.pb.go"; then
+        mv ${1}_grpc.pb.go ${1}_go_proto
+    fi
 }
 
 for api in ${GRAFEAS_PROTOS[@]} ; do
-  generate ${api}
+    generate ${api}
 done
 
 # finally, compile rode protobufs

--- a/server/healthz.go
+++ b/server/healthz.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"context"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+type HealthzServer interface {
+	grpc_health_v1.HealthServer
+	Ready()
+	NotReady()
+}
+
+type healthzServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+	ready  bool
+	logger *zap.Logger
+}
+
+func NewHealthzServer(logger *zap.Logger) HealthzServer {
+	return &healthzServer{
+		logger: logger,
+	}
+}
+
+func (h *healthzServer) Check(context.Context, *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	log := h.logger.Named("Check")
+	log.Debug("received grpc health check")
+
+	if h.ready {
+		return &grpc_health_v1.HealthCheckResponse{
+			Status: grpc_health_v1.HealthCheckResponse_SERVING,
+		}, nil
+	}
+
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+	}, nil
+}
+
+// Watch is unimplemented for now
+func (h *healthzServer) Watch(*grpc_health_v1.HealthCheckRequest, grpc_health_v1.Health_WatchServer) error {
+	return status.Error(codes.Unimplemented, "health watching is not supported yet")
+}
+
+func (h *healthzServer) Ready() {
+	h.ready = true
+}
+
+func (h *healthzServer) NotReady() {
+	h.ready = false
+}

--- a/server/healthz_test.go
+++ b/server/healthz_test.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+var _ = Describe("healthz server", func() {
+	var healthzServer HealthzServer
+
+	BeforeEach(func() {
+		healthzServer = NewHealthzServer(logger.Named("healthz server test"))
+	})
+
+	When("a health check is received", func() {
+		It("should respond with 'SERVING' when ready", func() {
+			healthzServer.Ready()
+			res, err := healthzServer.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.Status).To(BeEquivalentTo(grpc_health_v1.HealthCheckResponse_SERVING))
+		})
+
+		It("should respond with 'NOT_SERVING' when not ready", func() {
+			healthzServer.NotReady()
+			res, err := healthzServer.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.Status).To(BeEquivalentTo(grpc_health_v1.HealthCheckResponse_NOT_SERVING))
+		})
+	})
+})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -19,7 +19,7 @@ var _ = Describe("rode server", func() {
 
 	BeforeEach(func() {
 		grafeasClient = &mockGrafeasClient{}
-		rodeServer = NewRodeServer(logger, grafeasClient)
+		rodeServer = NewRodeServer(logger.Named("rode server test"), grafeasClient)
 	})
 
 	When("occurrences are created", func() {

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,8 @@
+apiVersion: skaffold/v2alpha1
+kind: Config
+build:
+  local:
+    useBuildkit: true
+  artifacts:
+    - image: rode-api
+      context: ./


### PR DESCRIPTION
after getting started on the helm chart, I realized that the liveness and readiness probes wouldn't work with `httpGet`, so I started working on this to allow the kubelet to invoke `grpc_health_probe` to perform the health check instead.

next PR will be the helm chart, I promise :smile: