### PR TITLE
add helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
 rode
+!helm/rode/
 rode-api
 coverage.txt

--- a/helm/rode/.helmignore
+++ b/helm/rode/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/rode/Chart.yaml
+++ b/helm/rode/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+appVersion: "1.0"
+description: A Helm chart for rode
+name: rode
+version: 0.1.0
+dependencies:
+  - name: grafeas
+    version: 0.1.0
+    condition: grafeas.enabled

--- a/helm/rode/charts/grafeas/.helmignore
+++ b/helm/rode/charts/grafeas/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/rode/charts/grafeas/Chart.yaml
+++ b/helm/rode/charts/grafeas/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: grafeas
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/helm/rode/charts/grafeas/templates/NOTES.txt
+++ b/helm/rode/charts/grafeas/templates/NOTES.txt
@@ -1,0 +1,17 @@
+1. The Grafeas server can be accessed via port {{ .Values.service.port }} on the following DNS name from within your cluster:
+
+   {{ template "grafeas.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+2. Get the Grafeas URL to visit by running these commands in the same shell:
+{{ if contains "NodePort" .Values.service.type -}}
+     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "grafeas.fullname" . }})
+     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+     echo http://$NODE_IP:$NODE_PORT
+{{ else if contains "LoadBalancer" .Values.service.type -}}
+   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "grafeas.fullname" . }}'
+     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "grafeas.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}') http://$SERVICE_IP:{{ .Values.service.port -}}
+{{ else if contains "ClusterIP"  .Values.service.type }}
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "grafeas.fullname" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{.Values.container.port }}
+{{- end }}

--- a/helm/rode/charts/grafeas/templates/_helpers.tpl
+++ b/helm/rode/charts/grafeas/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "grafeas.name" -}}
+{{- default .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "grafeas.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "grafeas.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/rode/charts/grafeas/templates/configmap.yaml
+++ b/helm/rode/charts/grafeas/templates/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafeas
+data:
+  config: |
+    grafeas:
+      # Grafeas api server config
+      api:
+        # Endpoint address
+        address: "0.0.0.0:{{ .Values.container.port }}"
+{{- if eq .Values.certificates.enabled true }}
+        # PKI configuration
+        cafile: /certificates/ca.crt
+        keyfile: /certificates/server.key
+        certfile: /certificates/server.crt
+{{- end }}
+        cors_allowed_origins:
+        # - "http://example.net"
+      storage_type: {{ .Values.persistence.storageType }}
+      embedded:
+        # Path to embedded database
+        path: "/data/grafeas.db"

--- a/helm/rode/charts/grafeas/templates/deployment.yaml
+++ b/helm/rode/charts/grafeas/templates/deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "grafeas.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "grafeas.name" . }}
+    helm.sh/chart: {{ include "grafeas.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "grafeas.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "grafeas.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/grafeas-server"]
+          args: ["--config=/etc/config/config.yaml"]
+          ports:
+            - name: grafeas
+              containerPort: {{ .Values.container.port }}
+              protocol: TCP
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config
+{{- if eq .Values.certificates.enabled true }}
+          - name: certificates
+            mountPath: /certificates
+{{- end }}
+{{- if .Values.persistence.enabled }}
+{{- if eq .Values.persistence.storageType "embedded" }}
+          - name: persistent-volume
+            mountPath: /data
+{{- end }}
+{{- end }}
+          resources:
+{{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+             tcpSocket:
+               port: grafeas
+             initialDelaySeconds: {{ .Values.livenessprobe.initialDelaySeconds }}
+             periodSeconds: {{ .Values.livenessprobe.periodSeconds }}
+             failureThreshold: {{ .Values.livenessprobe.failureThreshold }}
+          readinessProbe:
+             tcpSocket:
+               port: grafeas
+             initialDelaySeconds: {{ .Values.readinessprobe.initialDelaySeconds }}
+             periodSeconds: {{ .Values.readinessprobe.periodSeconds }}
+             failureThreshold: {{ .Values.readinessprobe.failureThreshold }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: grafeas
+            items:
+            - key: config
+              path: config.yaml
+{{- if .Values.certificates.enabled }}
+        - name: certificates
+          secret:
+            secretName: {{ .Values.certificates.name }}
+{{- end }}
+{{- if .Values.persistence.enabled }}
+{{- if eq .Values.persistence.storageType "embedded" }}
+        - name: persistent-volume
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.claimName }}
+{{- end}}
+{{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/helm/rode/charts/grafeas/templates/secrets.yaml
+++ b/helm/rode/charts/grafeas/templates/secrets.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.secret.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.certificates.name }}
+  labels:
+    app: {{ template "grafeas.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+type: Opaque
+data:
+  ca.crt: {{ .Values.certificates.ca | b64enc }}
+  server.crt : {{ .Values.certificates.cert | b64enc }}
+  server.key: {{ .Values.certificates.key | b64enc }}
+{{- end }}

--- a/helm/rode/charts/grafeas/templates/service.yaml
+++ b/helm/rode/charts/grafeas/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "grafeas.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "grafeas.name" . }}
+    helm.sh/chart: {{ include "grafeas.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.container.port }}
+      protocol: TCP
+      name: grafeas
+  selector:
+    app.kubernetes.io/name: {{ include "grafeas.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/rode/charts/grafeas/values.yaml
+++ b/helm/rode/charts/grafeas/values.yaml
@@ -1,0 +1,80 @@
+replicaCount: 1
+
+secret:
+  enabled: false
+
+## Grafeas image version
+image:
+  repository: us.gcr.io/grafeas
+  name: grafeas-server
+  tag: v0.1.6
+  pullPolicy: IfNotPresent
+
+nameOverride: "grafeas-server"
+fullnameOverride: "grafeas-server"
+
+## Specify a service type
+## ClusterIP is default
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+service:
+  type: ClusterIP
+  port: 8080
+
+container:
+  port: 8080
+
+## Persist data to a persistent volume. This is both a volume for certificates, Grafeas config and data volume.
+## enabled: false results in no persistent volumes and persistent volume claims being created
+## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+##
+persistence:
+  enabled: false
+  # The name of persistent volume to use
+  # persistent volume is used for storing the embedded grafeas data
+  claimName: "grafeas"
+  # The type of storage used, supported options: memstore or embedded
+  # REMARK: embedded storage requires a persistent volume
+  storageType: "memstore"
+
+# Certificates for mutual authentication
+certificates:
+  enabled: false
+  name: grafeas-ssl-certs
+  ca: |-
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+  cert: |-
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+  key: |-
+      -----BEGIN RSA PRIVATE KEY-----
+      ...
+      -----END RSA PRIVATE KEY-----
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+## Customize liveness, readiness and startup probes
+livenessprobe:
+  # Initial delay for liveness probe - value based on pod startup average of ~12 seconds using default resource limits above
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  # Failure threshold is calculated as initialDelaySeconds + (failureThreshold * periodSeconds) based on worst case startup time of 45 seconds
+  failureThreshold: 3
+
+readinessprobe:
+  # Initial delay for readiness probe - value based on pod startup average of ~12 seconds using default resource limits above
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  # Failure threshold is calculated as initialDelaySeconds + (failureThreshold * periodSeconds) based on worst case startup time of 45 seconds
+  failureThreshold: 3

--- a/helm/rode/templates/_helpers.tpl
+++ b/helm/rode/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rode.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rode.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rode.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/rode/templates/deployment.yaml
+++ b/helm/rode/templates/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "rode.fullname" . }}
+  labels:
+    app: {{ template "rode.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.podLabels }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.podAnnotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "rode.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "rode.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      securityContext:
+        fsGroup: 65534
+      initContainers:
+        - name: wait-for-grafeas
+          image: curlimages/curl:7.73.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              until curl --output /dev/null --silent --fail --max-time 2 {{ .Values.grafeasHost }}/v1beta1/projects; do sleep 1; done;
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--port={{ .Values.container.port }}"
+            - "--grafeas-host={{ .Values.grafeasHost }}"
+          ports:
+            - containerPort: {{ .Values.container.port }}
+          {{- with .Values.extraEnv }}
+          env:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+          readinessProbe:
+            exec:
+              command: ["/grpc_health_probe", "-addr=:{{ .Values.container.port }}"]
+            initialDelaySeconds: 5
+          livenessProbe:
+            exec:
+              command: ["/grpc_health_probe", "-addr=:{{ .Values.container.port }}"]
+            initialDelaySeconds: 5
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}

--- a/helm/rode/templates/service.yaml
+++ b/helm/rode/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rode.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "rode.name" . }}
+    helm.sh/chart: {{ include "rode.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ template "rode.name" . }}
+    release: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.container.port }}
+      {{- if and (eq .Values.service.type "NodePort") (.Values.service.nodePort) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+      protocol: TCP
+      name: rode

--- a/helm/rode/values.yaml
+++ b/helm/rode/values.yaml
@@ -1,0 +1,44 @@
+# Default values for rode.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+grafeas:
+  enabled: true
+  container:
+    port: 8080
+  service:
+    port: 8080
+  persistence:
+    enabled: false
+    storageType: memstore
+
+grafeasHost: "grafeas-server:8080"
+
+image:
+  repository: "harbor.toolchain.lead.prod.liatr.io/public/rode"
+  tag: ""
+  pullPolicy: IfNotPresent
+
+extraEnv: []
+
+container:
+  port: 50051
+service:
+  type: ClusterIP
+  port: 50051
+
+tolerations: []
+affinity: {}
+podLabels: {}
+nodeSelector: {}
+podAnnotations: {}
+
+replicaCount: 1
+
+resources:
+  limits:
+    cpu: 128m
+    memory: 64Mi
+  requests:
+    cpu: 64m
+    memory: 32Mi

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,5 +4,25 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: rode-api
+    - image: rode
       context: ./
+deploy:
+  helm:
+    releases:
+      - name: rode
+        chartPath: helm/rode
+        skipBuildDependencies: true
+        wait: true
+        values:
+          image: rode
+        imageStrategy:
+          helm: {}
+profiles:
+  - name: local
+    activation:
+      - kubeContext: docker-for-desktop
+      - kubeContext: docker-desktop
+    patches:
+      - op: add
+        path: /deploy/helm/releases/0/namespace
+        value: default


### PR DESCRIPTION
also added the official grafeas helm chart as a vendored dependency, since they don't publish it anywhere.  using memstore for now since their helm chart expects you to provide your own pvc when using embedded storage.